### PR TITLE
Bound original function name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh8/nestjs-grpc-transport",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresh8/nestjs-grpc-transport",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "GRPC transport layer for the NestJS framework",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/rpc-decorator.ts
+++ b/src/rpc-decorator.ts
@@ -21,6 +21,11 @@ export default (
     return original.bind(this)(...args)
   }
 
+  Object.defineProperty(descriptor.value, 'name', {
+    value: original.name,
+    writable: false
+  })
+
   Reflect.defineMetadata(
     PATTERN_METADATA,
     { rpc: propertyKey },

--- a/test/rpc-decorator.spec.ts
+++ b/test/rpc-decorator.spec.ts
@@ -24,14 +24,20 @@ describe('@rpc', () => {
   }
 
   it('should not mutate a method', async () => {
-    const controller: any = new TestController()
+    const controller = new TestController()
     const res = await controller.sayHello({ name: 'Tyrion' })
 
     expect(res).to.deep.equal({ message: 'Hello, Tyrion :)' })
   })
 
+  it('should retain the original function name', () => {
+    const controller = new TestController()
+
+    expect(controller.sayHello.name).to.equal('sayHello')
+  })
+
   it('should define metadata, needed by nest', () => {
-    const controller: any = new TestController()
+    const controller = new TestController()
 
     expect(
       Reflect.getMetadata(PATTERN_METADATA, controller.sayHello)


### PR DESCRIPTION
Accessing `handler.name` would be undefined as it's wrapped in a nameless anonymous function. This PR should fix that 🌚 .